### PR TITLE
Generate constant for types without arguments

### DIFF
--- a/example/bin/example.dart
+++ b/example/bin/example.dart
@@ -2,7 +2,7 @@ import 'sealed/nullsafe/data/generic/result_single_1.dart';
 import 'sealed/nullsafe/data/simple/weather.dart';
 
 void main() {
-  final a = Weather.sunny();
+  final a = Weather.sunny;
   final b = Weather.rainy(rain: 12);
   final c = Weather.windy(velocity: 1.5, angle: null);
 

--- a/example/bin/sealed/nullsafe/data/simple/meta.sealed.dart
+++ b/example/bin/sealed/nullsafe/data/simple/meta.sealed.dart
@@ -19,8 +19,6 @@ part of 'meta.dart';
 abstract class Weather {
   const Weather._internal();
 
-  const factory Weather.sunny() = PrefixSunny;
-
   const factory Weather.rainy({
     required int rain,
   }) = BadWeather;
@@ -29,6 +27,8 @@ abstract class Weather {
     required double velocity,
     double? angle,
   }) = VeryBadWeather;
+
+  static const Weather sunny = PrefixSunny();
 
   bool get isSunny => this is PrefixSunny;
 
@@ -297,8 +297,6 @@ class VeryBadWeather extends Weather {
 abstract class ApiError {
   const ApiError._internal();
 
-  const factory ApiError.internetError() = InternetError;
-
   const factory ApiError.serverError({
     required int code,
   }) = ServerError;
@@ -306,6 +304,8 @@ abstract class ApiError {
   const factory ApiError.otherError({
     String? message,
   }) = OtherError;
+
+  static const ApiError internetError = InternetError();
 
   bool get isInternetError => this is InternetError;
 

--- a/example/bin/sealed/nullsafe/data/simple/weather.sealed.dart
+++ b/example/bin/sealed/nullsafe/data/simple/weather.sealed.dart
@@ -19,8 +19,6 @@ part of 'weather.dart';
 abstract class Weather {
   const Weather._internal();
 
-  const factory Weather.sunny() = WeatherSunny;
-
   const factory Weather.rainy({
     required int rain,
   }) = WeatherRainy;
@@ -29,6 +27,8 @@ abstract class Weather {
     required double velocity,
     double? angle,
   }) = WeatherWindy;
+
+  static const Weather sunny = WeatherSunny();
 
   bool get isSunny => this is WeatherSunny;
 

--- a/example/bin/sealed/nullsafe/distinct/simple/weather.sealed.dart
+++ b/example/bin/sealed/nullsafe/distinct/simple/weather.sealed.dart
@@ -19,8 +19,6 @@ part of 'weather.dart';
 abstract class Weather {
   const Weather._internal();
 
-  const factory Weather.sunny() = WeatherSunny;
-
   const factory Weather.rainy({
     required int rain,
   }) = WeatherRainy;
@@ -29,6 +27,8 @@ abstract class Weather {
     required double velocity,
     double? angle,
   }) = WeatherWindy;
+
+  static const Weather sunny = WeatherSunny();
 
   bool get isSunny => this is WeatherSunny;
 

--- a/example/bin/sealed/nullsafe/identity/simple/weather.sealed.dart
+++ b/example/bin/sealed/nullsafe/identity/simple/weather.sealed.dart
@@ -19,8 +19,6 @@ part of 'weather.dart';
 abstract class Weather {
   const Weather._internal();
 
-  const factory Weather.sunny() = WeatherSunny;
-
   const factory Weather.rainy({
     required int rain,
   }) = WeatherRainy;
@@ -29,6 +27,8 @@ abstract class Weather {
     required double velocity,
     double? angle,
   }) = WeatherWindy;
+
+  static const Weather sunny = WeatherSunny();
 
   bool get isSunny => this is WeatherSunny;
 

--- a/sealed_writer/lib/src/writer/top/top_builder_writer.dart
+++ b/sealed_writer/lib/src/writer/top/top_builder_writer.dart
@@ -57,32 +57,25 @@ class TopBuilderWriter extends BaseUtilsWriter {
         ';',
       ].joinParts();
 
-  /// ex. factory Weather.sunny() = WeatherSunny;
+  /// ex. static const Weather sunny = WeatherSunny();
   ///
   /// ex. factory Result.success(...) = ResultSuccess<T>;
   String topFactoryBuilder(ManifestItem item) => [
-        'const factory $top.${subLower(item)}',
-        topBuilderDecArgs(item),
-        ' = ',
-        subCall(item),
-        ';',
-      ].joinParts();
-
-  /// Only generated if type has no parameters.
-  ///
-  /// ex. static const  sunny = Weather.sunny();
-  String topConstantBuilder(ManifestItem item) => [
-        if (item.fields.isEmpty) ...<String>[
-          'static const ${subLower(item)}',
+        if (item.fields.isNotEmpty) ...<String>[
+          'const factory $top.${subLower(item)}',
+          topBuilderDecArgs(item),
           ' = ',
-          '$top.${subLower(item)}',
+          subCall(item),
+          ';',
+        ],
+        if (item.fields.isEmpty) ...<String>[
+          'static const $top ${subLower(item)}',
+          ' = ',
+          subCall(item),
           '();',
         ]
       ].joinParts();
 
   /// top builder methods
-  Iterable<String> topBuilderMethods() => [
-        ...manifest.items.map(topFactoryBuilder),
-        ...manifest.items.map(topConstantBuilder)
-      ];
+  Iterable<String> topBuilderMethods() => manifest.items.map(topFactoryBuilder);
 }

--- a/sealed_writer/lib/src/writer/top/top_builder_writer.dart
+++ b/sealed_writer/lib/src/writer/top/top_builder_writer.dart
@@ -68,6 +68,21 @@ class TopBuilderWriter extends BaseUtilsWriter {
         ';',
       ].joinParts();
 
+  /// Only generated if type has no parameters.
+  ///
+  /// ex. static const  sunny = Weather.sunny();
+  String topConstantBuilder(ManifestItem item) => [
+        if (item.fields.isEmpty) ...<String>[
+          'static const ${subLower(item)}',
+          ' = ',
+          '$top.${subLower(item)}',
+          '();',
+        ]
+      ].joinParts();
+
   /// top builder methods
-  Iterable<String> topBuilderMethods() => manifest.items.map(topFactoryBuilder);
+  Iterable<String> topBuilderMethods() => [
+        ...manifest.items.map(topFactoryBuilder),
+        ...manifest.items.map(topConstantBuilder)
+      ];
 }


### PR DESCRIPTION
In my project I have a sealed class with an empty subtype that I use as default argument in a constructor. For that to work I need a static constant of that type, which I currently have to create myself as a top level field. This PR allows the writer to generate those constants as static const field inside the sealed class.

Edit: I've noticed that my first commit didn't produce correct Dart code, so I've fixed that in the second one. Unfortunately for that I needed to remove the factory method that was previously generated for such subtypes, which is a breaking change. If this isn't acceptable, this could be solved with an optional parameter on the `@Sealed()` annotation controlling the code generation. But before I go there, I'll wait for feedback if this is a welcome addition at all here first.

Excerpt of generated code:
```dart
abstract class Weather {
  static const Weather sunny = WeatherSunny();
  
  const factory Weather.rainy({required int rain}) = WeatherRainy;
}
```
